### PR TITLE
Prevent escaping in arguments

### DIFF
--- a/conjurcli.sh
+++ b/conjurcli.sh
@@ -4,9 +4,9 @@
 
 varname=${1}
 
-if [ -z ${varname} ]; then
+if [ -z "${varname}" ]; then
   echo -n "No argument received!"
   exit 1
 fi
 
-conjur variable value ${varname}
+conjur variable value "${varname}"


### PR DESCRIPTION
While for most cases the test condition is valid, when `$1` is a space-delimited string,
the `[]` evaluate it as extra parameters which can lead to escaping and erroneous
behavior.

Example:
Old code:
```
$ ./conjurcli.sh 'somevar -o 0 -eq 0'
No argument received
```